### PR TITLE
rotate through urls

### DIFF
--- a/bittrex_websocket/websocket_client.py
+++ b/bittrex_websocket/websocket_client.py
@@ -22,6 +22,7 @@ from ._auxiliary import BittrexConnection
 from ._logger import add_stream_logger, remove_stream_logger
 from ._queue_events import *
 from .constants import *
+import sys
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
changed _init_connection to loop through urls endlessly.  On unknown exception, we log what the exception was, wait 20s and retry with next url.

I've been running for a few hours without a thread crash, waiting to see if I get a 'Something wicked' error (and what it is).