### PR TITLE
Changed nodejs install command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,8 @@
 FROM python:3.6.3-alpine
 
 RUN   apk update && apk add --no-cache --virtual .build-deps \
-      g++ make libffi-dev openssl-dev git nodejs && \
+      g++ make libffi-dev openssl-dev git && \
+      apk --update add nodejs && \
       pip install 'cython>=0.25' && \
       pip install git+https://github.com/slazarov/python-bittrex-websocket.git@ && \
       apk del .build-deps && \


### PR DESCRIPTION
On my docker, the command "node --version" is only recognize if I install node.js with the command "apk --update add nodejs".