### PR TITLE
more flexible requests version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests[security]==2.20.0
+requests[security]>=2.20.0,<3.0.0
 Events==0.3
 websocket-client>=0.53.0
 signalr-client-threads

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 install_requires = \
     [
-        'requests[security]==2.20.0',
+        'requests[security]==2.20.0,<3.0.0',
         'Events==0.3',
         'websocket-client>=0.53.0',
         'signalr-client-threads'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 install_requires = \
     [
-        'requests[security]==2.20.0,<3.0.0',
+        'requests[security]>=2.20.0,<3.0.0',
         'Events==0.3',
         'websocket-client>=0.53.0',
         'signalr-client-threads'


### PR DESCRIPTION
the strict version requirement for `requests==2.20.0` is making this difficult to be used in projects such as [fastapi](https://github.com/tiangolo/fastapi/tree/master/fastapi) which requires `requests>=2.24.0`